### PR TITLE
Izpack 1406

### DIFF
--- a/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
@@ -244,7 +244,7 @@ public class DefaultVariablesTest
      * Tests simple dynamic variables.
      */
     @Test
-    public void testDynamicVariablesUnset()
+    public void testDynamicVariablesWithUserInput()
     {
         // set up conditions
         Map<String, Condition> conditions = new HashMap<String, Condition>();
@@ -258,38 +258,38 @@ public class DefaultVariablesTest
         rules.readConditionMap(conditions);
         ((DefaultVariables) variables).setRules(rules);
 
-        variables.add(createDynamicCheckonce("unset1", "a", "cond1+cond2"));
-        variables.add(createDynamicCheckonce("unset1", "b", "cond1+!cond2"));
+        variables.add(createDynamicCheckonce("var", "a", "cond1+cond2"));
+        variables.add(createDynamicCheckonce("var", "b", "cond1+!cond2"));
 
         // !cond1+!cond2
         variables.refresh();
-        assertNull(variables.get("unset1"));
+        assertNull(variables.get("var"));
 
         variables.set("condvar1", "x");
         // cond1+!cond2
         variables.refresh();
-        assertEquals("b", variables.get("unset1"));
+        assertEquals("b", variables.get("var"));
         variables.refresh(); // Double check whether it is a stable state (for instance on panel change)
-        assertEquals("b", variables.get("unset1"));
+        assertEquals("b", variables.get("var"));
 
         Set<String> blocked = new HashSet<String>();
         // we now do overwrite the variable on a UserInputPanel
-        blocked.add("unset1");
-        variables.set("unset1", "anothervalue");
+        blocked.add("var");
+        variables.set("var", "anothervalue");
         variables.registerBlockedVariableNames(blocked, this);
         variables.refresh(); // user input is stronger than other definitions
-        assertEquals("anothervalue", variables.get("unset1"));
+        assertEquals("anothervalue", variables.get("var"));
 
         variables.set("condvar2", "y"); // a conditions changes and wants to overwrite the variable
         variables.refresh();            // but user input still must survive
-        assertEquals("anothervalue", variables.get("unset1"));
+        assertEquals("anothervalue", variables.get("var"));
 
         // now the user goes back to the previous panel
         variables.unregisterBlockedVariableNames(blocked, this);
         variables.refresh(); // value must be changed as defined for cond1+cond2
-        assertEquals("a", variables.get("unset1"));
+        assertEquals("a", variables.get("var"));
         variables.refresh(); // Double check whether it is a stable state (for instance on panel change)
-        assertEquals("a", variables.get("unset1"));
+        assertEquals("a", variables.get("var"));
     }
 
     /**

--- a/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
@@ -273,17 +273,20 @@ public class DefaultVariablesTest
         assertEquals("b", variables.get("unset1"));
 
         Set<String> blocked = new HashSet<String>();
-        // prevent from being overridden by refresh (for instance as part of a UserInputPanel reached)
+        // we now do overwrite the variable on a UserInputPanel
         blocked.add("unset1");
         variables.set("unset1", "anothervalue");
         variables.registerBlockedVariableNames(blocked, this);
-        variables.refresh(); // Check keep overload from another source like a user input panel
+        variables.refresh(); // user input is stronger than other definitions
         assertEquals("anothervalue", variables.get("unset1"));
 
+        variables.set("condvar2", "y"); // a conditions changes and wants to overwrite the variable
+        variables.refresh();            // but user input still must survive
+        assertEquals("anothervalue", variables.get("unset1"));
+
+        // now the user goes back to the previous panel
         variables.unregisterBlockedVariableNames(blocked, this);
-        variables.set("condvar2", "y");
-        // cond1+cond2 - override the previous value
-        variables.refresh();
+        variables.refresh(); // value must be changed as defined for cond1+cond2
         assertEquals("a", variables.get("unset1"));
         variables.refresh(); // Double check whether it is a stable state (for instance on panel change)
         assertEquals("a", variables.get("unset1"));


### PR DESCRIPTION
The user value must be stable, even if other conditions change. This has not been tested yet.
As soon as the user switches back to the previous panel, the other sources for the variable must win again. This has been testet with a condition, that becomes true freshly. But it also must happen, if the condition was changed while the variable was in the blocked state.

So I've added some code to the test and I've documented the sequence in the comments, so the test case can be better understood.
