### PR TITLE
IZPACK-1406: Fix for getUnresolvedVariableNames()

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/variable/PlainConfigFileValue.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/variable/PlainConfigFileValue.java
@@ -83,6 +83,8 @@ public class PlainConfigFileValue extends ConfigFileValue implements Serializabl
     @Override
     public Set<String> getUnresolvedVariableNames()
     {
-        return parseUnresolvedVariableNames(location);
+        Set<String> unresolvedNames = super.getUnresolvedVariableNames();
+        unresolvedNames.add(location);
+        return parseUnresolvedVariableNames(unresolvedNames.toArray(new String[unresolvedNames.size()]));
     }
 }


### PR DESCRIPTION
All parameters of PlainConfigFileValue must be considered for getUnresolvedVariableNames(). Otherwise to computed variable resolution order will be wrong.
