### PR TITLE
different solution to ensure, that all variables are added to the graph

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
@@ -390,7 +390,7 @@ public abstract class PackagerBase implements IPackager
         {
             for (DynamicVariable var : dynVariables)
             {
-                boolean added = false;
+                graph.addVertex(var);
                 for (String childName : var.getUnresolvedVariableNames())
                 {
                     List<DynamicVariable> childVars = dynamicVariables.get(childName);
@@ -399,13 +399,8 @@ public abstract class PackagerBase implements IPackager
                         for (DynamicVariable childVar : childVars)
                         {
                             graph.addEdge(var, childVar);
-                            added = true;
                         }
                     }
-                }
-                if (!added)
-                {
-                    graph.addVertex(var);
                 }
             }
         }


### PR DESCRIPTION
> ... but more the this: Building the tree wasn't also ok, as I saw
> after fixing the parsing. If a variable hadn't had any unresolved
> references it hadn't been added to the graph, so the graph could be
> empty although there were variables (with static values) defined.

Good catch!

I did have a root element pointing to all variables. Therefore all variables were added implicit by this edge. Later I've discovered, that the root element wasn't needed and with removing the root, the implicit inclusion of all variables has gone also. :-(

But I suggest a different solution: Instead of bookkeeping with the variable added, it just could be added in any case. I think this is more readable.
