### PR TITLE
Code Cleanup fopr IZPACK-1406

### DIFF
--- a/izpack-compiler/src/test/java/com/izforge/izpack/compiler/DynVariableOrderTest.java
+++ b/izpack-compiler/src/test/java/com/izforge/izpack/compiler/DynVariableOrderTest.java
@@ -1,0 +1,178 @@
+/*
+ * IzPack - Copyright 2001-2012 Julien Ponge, All Rights Reserved.
+ *
+ * http://izpack.org/
+ * http://izpack.codehaus.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.compiler;
+
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.jar.JarFile;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.izforge.izpack.api.data.DynamicVariable;
+import com.izforge.izpack.compiler.container.TestCompilerContainer;
+import com.izforge.izpack.test.Container;
+import com.izforge.izpack.test.InstallFile;
+import com.izforge.izpack.test.junit.PicoRunner;
+
+/**
+ * Test for correct order of dynamic variable computation
+ */
+@RunWith(PicoRunner.class)
+@Container(TestCompilerContainer.class)
+public class DynVariableOrderTest
+{
+    static final String xmlDir="samples/dynvars/";  // Where we find our installer definitions
+    
+    private CompilerConfig compilerConfig;
+    private TestCompilerContainer testContainer;
+
+    List<String> orderedVarnames;
+
+    public DynVariableOrderTest(TestCompilerContainer container, CompilerConfig compilerConfig)
+    {
+        this.testContainer = container;
+        this.compilerConfig = compilerConfig;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setUp() throws Exception
+    {
+        compilerConfig.executeCompiler();
+        JarFile jar = testContainer.getComponent(JarFile.class);
+        InputStream ios = jar.getInputStream(jar.getEntry("resources/dynvariables"));
+        Object object = new ObjectInputStream(ios).readObject();
+        List<DynamicVariable> dynVars = (List<DynamicVariable>) object;
+        orderedVarnames = new ArrayList<String>(dynVars.size());
+        for (DynamicVariable var : dynVars) {
+            orderedVarnames.add(var.getName());
+        }
+        StringBuffer sb = new StringBuffer(
+                String.format("Installer built from '%s' has this ordering of variable computation:%n",
+                               testContainer.getXmlFileName()));
+        for (String name : orderedVarnames) {
+            sb.append(name).append(", ");
+        }
+        System.out.println(sb);
+    }
+
+    /**
+     * Test a simple dependency: a dynamic variable depends on a static variable and a second one standing alone
+     */
+    @Test
+    @InstallFile(xmlDir+"simpleDependency.xml")
+    public void testSimpleDependency() 
+    {
+        testOrder("static1", "dyn1");
+        testContained("dyn2");
+    }
+
+    /**
+     * Test a longer dependency of dynamic variables
+     */
+    @Test
+    @InstallFile(xmlDir+"deeperDependency.xml")
+    public void testDeeperDependency() 
+    {
+        testOrder("static1", "dyn1", "dyn2", "dyn3", "dyn4", "dyn5", "dyn6", "dyn7", "dyn8");
+    }
+
+    /**
+     * Test a longer dependency of variables in reversed order
+     */
+    @Test
+    @InstallFile(xmlDir+"forwardDependency.xml")
+    public void testforwardDependency() 
+    {
+        testOrder("static1", "dyn8", "dyn7", "dyn6", "dyn5", "dyn4", "dyn3", "dyn2", "dyn1");
+    }
+
+    /**
+     * Test a longer dependency of variables in mixed order
+     */
+    @Test
+    @InstallFile(xmlDir+"mixedDependency.xml")
+    public void testMixedDependency() 
+    {
+        testOrder("static1", "dyn1", "dyn5", "dyn4", "dyn6", "dyn3", "dyn7", "dyn2", "dyn8");
+    }
+
+    /**
+     * Test two separate dependency sequences
+     */
+    @Test
+    @InstallFile(xmlDir+"separateDependency.xml")
+    public void testSeparateDependency() 
+    {
+        testOrder("dyn7", "dyn5", "dyn3", "dyn1");
+        testOrder("dyn2", "dyn4", "dyn6", "dyn8");
+    }
+
+    /**
+     * Test two separate dependency sequences merging together
+     */
+    @Test
+    @InstallFile(xmlDir+"parallelDependency.xml")
+    public void testParallelDependency() 
+    {
+        testOrder("dyn7", "dyn5", "dyn3", "dyn1", "dyn10");
+        testOrder("dyn2", "dyn4", "dyn6", "dyn8", "dyn10");
+    }
+
+    private void testOrder(String... names)
+    {
+        String name1 = names[0];
+        String name2 ;
+        testContained(name1);
+        for (int i = 1; i < names.length; i++) {
+            name2 = names[i];
+            testContained(name2);
+            assertTrue(String.format("'%s' must come before '%s' in variables-list",name1,name2), seachInList(name1) < seachInList(name2));
+            name1 = name2;
+        }
+    }
+
+    private void testContained(String name)
+    {
+        assertTrue(String.format("variable '%s' must be contained in variables-list",name), seachInList(name)>-1);
+    }
+
+    private int seachInList(String name)
+    {
+        ListIterator<String> it = orderedVarnames.listIterator();
+        while (it.hasNext())
+        {
+            if (it.next().equals(name))
+            {
+                return it.previousIndex();
+            }
+        }
+        return -1;
+    }
+
+}
+

--- a/izpack-compiler/src/test/java/com/izforge/izpack/compiler/DynVariableOrderTest.java
+++ b/izpack-compiler/src/test/java/com/izforge/izpack/compiler/DynVariableOrderTest.java
@@ -39,7 +39,12 @@ import com.izforge.izpack.test.InstallFile;
 import com.izforge.izpack.test.junit.PicoRunner;
 
 /**
- * Test for correct order of dynamic variable computation
+ * Tests for correct order of dynamic variable computation
+ * 
+ * Cave: 
+ * o If this tests do fail, we definitely have a problem in computation of dynamic variables.
+ * o If this test do succeed, this is NOT a guarantee for correct implementation. The order
+ *   of variable computation can be correct by random and may fail on other examples
  */
 @RunWith(PicoRunner.class)
 @Container(TestCompilerContainer.class)
@@ -141,6 +146,18 @@ public class DynVariableOrderTest
     {
         testOrder("dyn7", "dyn5", "dyn3", "dyn1", "dyn10");
         testOrder("dyn2", "dyn4", "dyn6", "dyn8", "dyn10");
+    }
+
+    /**
+     * Test variables with values with indirect variable references
+     */
+    @Test
+    @InstallFile(xmlDir+"complexValueDependency.xml")
+    public void testComplexValueDependency() 
+    {
+        testOrder("file", "ini"); testOrder("key", "ini"); testOrder("section", "ini");
+        testOrder("file", "opt"); testOrder("key", "opt");
+        testOrder("file", "xml"); testOrder("key", "xml");
     }
 
     private void testOrder(String... names)

--- a/izpack-compiler/src/test/java/com/izforge/izpack/compiler/container/TestCompilerContainer.java
+++ b/izpack-compiler/src/test/java/com/izforge/izpack/compiler/container/TestCompilerContainer.java
@@ -59,6 +59,15 @@ public class TestCompilerContainer extends CompilerContainer
      */
     private FrameworkMethod testMethod;
 
+    /**
+     * The name of the installer.xml used in this installer
+     */
+    private String installFileName;
+
+    /**
+     * @return the installFileName
+     */
+    public String getXmlFileName() { return installFileName; }
 
     /**
      * Constructs a <tt>TestCompilerContainer</tt>.
@@ -112,7 +121,7 @@ public class TestCompilerContainer extends CompilerContainer
         {
             installFile = testClass.getAnnotation(InstallFile.class);
         }
-        String installFileName = installFile.value();
+        installFileName = installFile.value();
 
         File installerFile = FileUtil.convertUrlToFile(getClass().getClassLoader().getResource(installFileName));
         File baseDir = installerFile.getParentFile();

--- a/izpack-compiler/src/test/resources/samples/dynvars/complexValueDependency.xml
+++ b/izpack-compiler/src/test/resources/samples/dynvars/complexValueDependency.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="iso-8859-1" standalone="yes" ?>
+<izpack:installation version="5.0" xmlns:izpack="http://izpack.org/schema/installation"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd">
+    <info>
+        <appname>Test Installation</appname>
+        <appversion>1.4 beta 666</appversion>
+        <authors>
+            <author name="Super sora" email="sora@superman.org"/>
+        </authors>
+        <url>http://www.anotherworld-inspace-website.net/</url>
+
+    </info>
+
+    <guiprefs width="640" height="480" resizable="yes"/>
+    <locale>
+        <langpack iso3="eng"/>
+    </locale>
+
+    <variables>
+        <variable name="file"     value="file" />
+        <variable name="section"  value="section" />
+        <variable name="key"      value="key" />
+    </variables>
+    
+    <dynamicvariables>
+        <variable name="ini" type="ini"     file="${file}" key="${key}" section="${section}"/>
+        <variable name="opt" type="options" file="${file}" key="${key}" />
+        <variable name="xml" type="xml"     file="${file}" key="${key}" />
+    </dynamicvariables>
+
+    <panels>
+        <panel classname="HelloPanel"/>
+        <panel classname="SimpleFinishPanel"/>
+    </panels>
+
+    <packs>
+        <pack name="Base" required="yes">
+            <description>The base files</description>
+        </pack>
+    </packs>
+</izpack:installation>

--- a/izpack-compiler/src/test/resources/samples/dynvars/deeperDependency.xml
+++ b/izpack-compiler/src/test/resources/samples/dynvars/deeperDependency.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="iso-8859-1" standalone="yes" ?>
+<izpack:installation version="5.0" xmlns:izpack="http://izpack.org/schema/installation"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd">
+    <info>
+        <appname>Test Installation</appname>
+        <appversion>1.4 beta 666</appversion>
+        <authors>
+            <author name="Super sora" email="sora@superman.org"/>
+        </authors>
+        <url>http://www.anotherworld-inspace-website.net/</url>
+
+    </info>
+
+    <guiprefs width="640" height="480" resizable="yes"/>
+    <locale>
+        <langpack iso3="eng"/>
+    </locale>
+
+    <variables>
+        <variable name="static1" value="value1" />
+    </variables>
+    
+    <dynamicvariables>
+        <variable name="dyn1" value="${static1}" />
+        <variable name="dyn2" value="${dyn1}" />
+        <variable name="dyn3" value="${dyn2}" />
+        <variable name="dyn4" value="${dyn3}" />
+        <variable name="dyn5" value="${dyn4}" />
+        <variable name="dyn6" value="${dyn5}" />
+        <variable name="dyn7" value="${dyn6}" />
+        <variable name="dyn8" value="${dyn7}" />
+    </dynamicvariables>
+
+    <panels>
+        <panel classname="HelloPanel"/>
+        <panel classname="SimpleFinishPanel"/>
+    </panels>
+
+    <packs>
+        <pack name="Base" required="yes">
+            <description>The base files</description>
+        </pack>
+    </packs>
+</izpack:installation>

--- a/izpack-compiler/src/test/resources/samples/dynvars/forwardDependency.xml
+++ b/izpack-compiler/src/test/resources/samples/dynvars/forwardDependency.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="iso-8859-1" standalone="yes" ?>
+<izpack:installation version="5.0" xmlns:izpack="http://izpack.org/schema/installation"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd">
+    <info>
+        <appname>Test Installation</appname>
+        <appversion>1.4 beta 666</appversion>
+        <authors>
+            <author name="Super sora" email="sora@superman.org"/>
+        </authors>
+        <url>http://www.anotherworld-inspace-website.net/</url>
+
+    </info>
+
+    <guiprefs width="640" height="480" resizable="yes"/>
+    <locale>
+        <langpack iso3="eng"/>
+    </locale>
+
+    <variables>
+        <variable name="static1" value="value1" />
+    </variables>
+    
+    <dynamicvariables>
+        <variable name="dyn1" value="${dyn2}" />
+        <variable name="dyn2" value="${dyn3}" />
+        <variable name="dyn3" value="${dyn4}" />
+        <variable name="dyn4" value="${dyn5}" />
+        <variable name="dyn5" value="${dyn6}" />
+        <variable name="dyn6" value="${dyn7}" />
+        <variable name="dyn7" value="${dyn8}" />
+        <variable name="dyn8" value="${static1}" />
+    </dynamicvariables>
+
+    <panels>
+        <panel classname="HelloPanel"/>
+        <panel classname="SimpleFinishPanel"/>
+    </panels>
+
+    <packs>
+        <pack name="Base" required="yes">
+            <description>The base files</description>
+        </pack>
+    </packs>
+</izpack:installation>

--- a/izpack-compiler/src/test/resources/samples/dynvars/mixedDependency.xml
+++ b/izpack-compiler/src/test/resources/samples/dynvars/mixedDependency.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="iso-8859-1" standalone="yes" ?>
+<izpack:installation version="5.0" xmlns:izpack="http://izpack.org/schema/installation"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd">
+    <info>
+        <appname>Test Installation</appname>
+        <appversion>1.4 beta 666</appversion>
+        <authors>
+            <author name="Super sora" email="sora@superman.org"/>
+        </authors>
+        <url>http://www.anotherworld-inspace-website.net/</url>
+
+    </info>
+
+    <guiprefs width="640" height="480" resizable="yes"/>
+    <locale>
+        <langpack iso3="eng"/>
+    </locale>
+
+    <variables>
+        <variable name="static1" value="value1" />
+    </variables>
+    
+    <dynamicvariables>
+        <variable name="dyn1" value="${static1}" />
+        <variable name="dyn2" value="${dyn7}" />
+        <variable name="dyn3" value="${dyn6}" />
+        <variable name="dyn4" value="${dyn5}" />
+        <variable name="dyn5" value="${dyn1}" />
+        <variable name="dyn6" value="${dyn4}" />
+        <variable name="dyn7" value="${dyn3}" />
+        <variable name="dyn8" value="${dyn2}" />
+    </dynamicvariables>
+
+    <panels>
+        <panel classname="HelloPanel"/>
+        <panel classname="SimpleFinishPanel"/>
+    </panels>
+
+    <packs>
+        <pack name="Base" required="yes">
+            <description>The base files</description>
+        </pack>
+    </packs>
+</izpack:installation>

--- a/izpack-compiler/src/test/resources/samples/dynvars/parallelDependency.xml
+++ b/izpack-compiler/src/test/resources/samples/dynvars/parallelDependency.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="iso-8859-1" standalone="yes" ?>
+<izpack:installation version="5.0" xmlns:izpack="http://izpack.org/schema/installation"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd">
+    <info>
+        <appname>Test Installation</appname>
+        <appversion>1.4 beta 666</appversion>
+        <authors>
+            <author name="Super sora" email="sora@superman.org"/>
+        </authors>
+        <url>http://www.anotherworld-inspace-website.net/</url>
+
+    </info>
+
+    <guiprefs width="640" height="480" resizable="yes"/>
+    <locale>
+        <langpack iso3="eng"/>
+    </locale>
+
+    <variables>
+        <variable name="static1" value="value1" />
+    </variables>
+    
+    <dynamicvariables>
+        <variable name="dyn1" value="${dyn3}" />
+        <variable name="dyn2" value="value2" />
+        <variable name="dyn3" value="${dyn5}" />
+        <variable name="dyn4" value="${dyn2}" />
+        <variable name="dyn5" value="${dyn7}" />
+        <variable name="dyn6" value="${dyn4}" />
+        <variable name="dyn7" value="value7" />
+        <variable name="dyn8" value="${dyn6}" />
+        <variable name="dyn10" value="${dyn1}${dyn8}" />
+    </dynamicvariables>
+
+    <panels>
+        <panel classname="HelloPanel"/>
+        <panel classname="SimpleFinishPanel"/>
+    </panels>
+
+    <packs>
+        <pack name="Base" required="yes">
+            <description>The base files</description>
+        </pack>
+    </packs>
+</izpack:installation>

--- a/izpack-compiler/src/test/resources/samples/dynvars/separateDependency.xml
+++ b/izpack-compiler/src/test/resources/samples/dynvars/separateDependency.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="iso-8859-1" standalone="yes" ?>
+<izpack:installation version="5.0" xmlns:izpack="http://izpack.org/schema/installation"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd">
+    <info>
+        <appname>Test Installation</appname>
+        <appversion>1.4 beta 666</appversion>
+        <authors>
+            <author name="Super sora" email="sora@superman.org"/>
+        </authors>
+        <url>http://www.anotherworld-inspace-website.net/</url>
+
+    </info>
+
+    <guiprefs width="640" height="480" resizable="yes"/>
+    <locale>
+        <langpack iso3="eng"/>
+    </locale>
+
+    <variables>
+        <variable name="static1" value="value1" />
+    </variables>
+    
+    <dynamicvariables>
+        <variable name="dyn1" value="${dyn3}" />
+        <variable name="dyn2" value="value2" />
+        <variable name="dyn3" value="${dyn5}" />
+        <variable name="dyn4" value="${dyn2}" />
+        <variable name="dyn5" value="${dyn7}" />
+        <variable name="dyn6" value="${dyn4}" />
+        <variable name="dyn7" value="value7" />
+        <variable name="dyn8" value="${dyn6}" />
+    </dynamicvariables>
+
+    <panels>
+        <panel classname="HelloPanel"/>
+        <panel classname="SimpleFinishPanel"/>
+    </panels>
+
+    <packs>
+        <pack name="Base" required="yes">
+            <description>The base files</description>
+        </pack>
+    </packs>
+</izpack:installation>

--- a/izpack-compiler/src/test/resources/samples/dynvars/simpleDependency.xml
+++ b/izpack-compiler/src/test/resources/samples/dynvars/simpleDependency.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="iso-8859-1" standalone="yes" ?>
+<izpack:installation version="5.0" xmlns:izpack="http://izpack.org/schema/installation"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd">
+    <info>
+        <appname>Test Installation</appname>
+        <appversion>1.4 beta 666</appversion>
+        <authors>
+            <author name="Super sora" email="sora@superman.org"/>
+        </authors>
+        <url>http://www.anotherworld-inspace-website.net/</url>
+
+    </info>
+
+    <guiprefs width="640" height="480" resizable="yes"/>
+    <locale>
+        <langpack iso3="eng"/>
+    </locale>
+
+    <variables>
+        <variable name="static1" value="value1" />
+    </variables>
+    
+    <dynamicvariables>
+        <variable name="dyn1" value="${static1}" />
+        <variable name="dyn2" value="value2"/>
+    </dynamicvariables>
+
+    <panels>
+        <panel classname="HelloPanel"/>
+        <panel classname="SimpleFinishPanel"/>
+    </panels>
+
+    <packs>
+        <pack name="Base" required="yes">
+            <description>The base files</description>
+        </pack>
+    </packs>
+</izpack:installation>

--- a/izpack-core/src/main/java/com/izforge/izpack/core/variable/ConfigFileValue.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/variable/ConfigFileValue.java
@@ -24,7 +24,6 @@ package com.izforge.izpack.core.variable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
-import java.util.HashSet;
 import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -217,12 +216,11 @@ public abstract class ConfigFileValue extends ValueImpl implements Serializable
     @Override
     public Set<String> getUnresolvedVariableNames()
     {
-        Set<String> unresolvedNames = new HashSet<String>();
-        unresolvedNames.add(key);
+        Set<String> unresolvedNames = parseUnresolvedVariableNames(key); 
         if (type == CONFIGFILE_TYPE_INI)
         {
-            unresolvedNames.add(section);
+            unresolvedNames.addAll(parseUnresolvedVariableNames(section));
         }
-        return parseUnresolvedVariableNames(unresolvedNames.toArray(new String[unresolvedNames.size()]));
+        return unresolvedNames;
     }
 }

--- a/izpack-core/src/main/java/com/izforge/izpack/core/variable/ExecValue.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/variable/ExecValue.java
@@ -22,7 +22,6 @@
 package com.izforge.izpack.core.variable;
 
 import java.io.Serializable;
-import java.util.HashSet;
 import java.util.Set;
 
 import com.izforge.izpack.api.substitutor.VariableSubstitutor;
@@ -145,15 +144,11 @@ public class ExecValue extends ValueImpl implements Serializable
     @Override
     public Set<String> getUnresolvedVariableNames()
     {
-        Set<String> unresolvedNames = new HashSet<String>();
+        Set<String> unresolvedNames = parseUnresolvedVariableNames(cmd);
         if (dir != null)
         {
-            unresolvedNames.add(dir);
+            unresolvedNames.addAll(parseUnresolvedVariableNames(dir));
         }
-        for (String c : cmd)
-        {
-            unresolvedNames.add(c);
-        }
-        return parseUnresolvedVariableNames(unresolvedNames.toArray(new String[unresolvedNames.size()]));
+        return unresolvedNames;
     }
 }

--- a/izpack-core/src/main/java/com/izforge/izpack/core/variable/PlainConfigFileValue.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/variable/PlainConfigFileValue.java
@@ -83,8 +83,8 @@ public class PlainConfigFileValue extends ConfigFileValue implements Serializabl
     @Override
     public Set<String> getUnresolvedVariableNames()
     {
-        Set<String> unresolvedNames = super.getUnresolvedVariableNames();
-        unresolvedNames.add(location);
-        return parseUnresolvedVariableNames(unresolvedNames.toArray(new String[unresolvedNames.size()]));
+        Set<String> unresolvedNames = parseUnresolvedVariableNames(location); 
+        unresolvedNames.addAll(super.getUnresolvedVariableNames());
+        return unresolvedNames;
     }
 }

--- a/izpack-core/src/main/java/com/izforge/izpack/core/variable/RegistryValue.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/variable/RegistryValue.java
@@ -191,6 +191,6 @@ public class RegistryValue extends ValueImpl implements Serializable
     @Override
     public Set<String> getUnresolvedVariableNames()
     {
-        return parseUnresolvedVariableNames(new String[]{root, key, value});
+        return parseUnresolvedVariableNames(root, key, value);
     }
 }

--- a/izpack-core/src/main/java/com/izforge/izpack/core/variable/ZipEntryConfigFileValue.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/variable/ZipEntryConfigFileValue.java
@@ -20,7 +20,6 @@
 package com.izforge.izpack.core.variable;
 
 import java.io.InputStream;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
@@ -121,10 +120,8 @@ public class ZipEntryConfigFileValue extends ConfigFileValue
     @Override
     public Set<String> getUnresolvedVariableNames()
     {
-        Set<String> unresolvedNames = new HashSet<String>();
+        Set<String> unresolvedNames = parseUnresolvedVariableNames(filename, entryname);
         unresolvedNames.addAll(super.getUnresolvedVariableNames());
-        unresolvedNames.add(getFilename());
-        unresolvedNames.add(getEntryname());
-        return parseUnresolvedVariableNames(unresolvedNames.toArray(new String[unresolvedNames.size()]));
+        return unresolvedNames;
     }
 }

--- a/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
@@ -267,8 +267,8 @@ public class DefaultVariablesTest
         rules.readConditionMap(conditions);
         ((DefaultVariables) variables).setRules(rules);
 
-        variables.add(createDynamicCheckonce("previous.wrapper.conf", "${INSTALL_PATH}/conf/wrapper.conf".replaceAll("/+", File.separator), "haveInstallPath"));
-        variables.add(createDynamicCheckonce("previous.wrapper.conf", "${INSTALL_PATH}/wrapper.conf".replaceAll("/+", File.separator), "haveInstallPath+!previous.wrapper.conf.exists"));
+        variables.add(createDynamicCheckonce("previous.wrapper.conf", "${INSTALL_PATH}/conf/wrapper.conf".replace("/", File.separator), "haveInstallPath"));
+        variables.add(createDynamicCheckonce("previous.wrapper.conf", "${INSTALL_PATH}/wrapper.conf".replace("/", File.separator), "haveInstallPath+!previous.wrapper.conf.exists"));
 
         File installPath = null;
         File confFile = null;


### PR DESCRIPTION
Hi,

I've made some cleanup for getUnresolvedVariableNames() so the code is easier to read.

Also it does avoid to instantiate objects. The toArray() does copy the complete set into a new array to be uncoupled from the initial one. So the old code did create two arrays instead of one.

I send this is a separate pull request, so you can decide, whether this is a good thing

Regards
 Tom
